### PR TITLE
Update requirements.txt for missing dependency [inquirer]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 requests
 python-inquirer
 langchain
+inquirer


### PR DESCRIPTION
I have tested this on a Mac and it gives me an error if you do not have inquirer installed.  I assume this was a missing dependency.

I followed through the instructions on the home page and got an error 

**with No Module name 'inquirer'**

Here is the output

```
 agent % python main.py
Traceback (most recent call last):
  File "/Users/xxxxx/agent/main.py", line 2, in <module>
    from generators.topic_generator import TopicGenerator
  File "/Users/xxxxx/agent/generators/topic_generator.py", line 4, in <module>
    from brands import Brand
  File "/Users/xxxx/agent/brands.py", line 2, in <module>
    import inquirer
ModuleNotFoundError: No module named 'inquirer'

I did the following command to fix the issue

```
pip install inquirer
```

This PR recommends to add this into the requirements.txt